### PR TITLE
refactor(Polyfill): use `!==` over `^` in boolean checks

### DIFF
--- a/src/polyfill.mjs
+++ b/src/polyfill.mjs
@@ -93,7 +93,7 @@ export function fma_correct(x, y, z) {
       var t = hi * 134217729; //2**27+1
       var hh = t + (hi - t), hl = hi - hh;
       if (!(hl & 1)) {
-        if ((LO > 0) ^ (hi < 0)) {
+        if ((LO > 0) !== (hi < 0)) {
           hi = next(hi, 1);
         } else {
           hi = next(hi, -1);


### PR DESCRIPTION
ref: https://github.com/munrocket/proposal-math-float/pull/1#issuecomment-868988123

The behavior in both the old and new code is the same:

```javascript
(1 > 0) ^ (1 < 0) // 1
(1 > 0) ^ (0 < 0) // 1
(0 > 0) ^ (1 < 0) // 0
(0 > 0) ^ (0 < 0) // 0
```

```javascript
(1 > 0) !== (1 < 0) // true
(1 > 0) !== (0 < 0) // true
(0 > 0) !== (1 < 0) // false
(0 > 0) !== (0 < 0) // false
```

And since it's doing a comparison between two boolean values inside an `if` condition, the latter is more correct.
